### PR TITLE
Update packages, readme, and stg_supplies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,5 @@ _Not implemented_
 To run this project in dbt Cloud:
 - Make a fork of this repo in your own GitHub organization
 - Import your forked repository into dbt Cloud
+- Run `dbt deps` to install package dependencies 
 - Run a job in your dbt Cloud Deployment Environment with the command `dbt build`

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -20,7 +20,7 @@ clean-targets:         # directories to be removed by `dbt clean`
   - "dbt_packages"
 
 vars:
-  truncate_timespan_to: "{{ dbt_utils.current_timestamp() }}"
+  truncate_timespan_to: "{{ current_timestamp() }}"
 
 models:
   demo_data:

--- a/models/staging/stg_supplies.sql
+++ b/models/staging/stg_supplies.sql
@@ -12,7 +12,7 @@ renamed as (
     select
 
         ----------  ids
-        {{ dbt_utils.surrogate_key(['id', 'sku']) }} as supply_uuid,
+        {{ dbt_utils.generate_surrogate_key(['id', 'sku']) }} as supply_uuid,
         id as supply_id,
         sku as product_id,
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,6 +1,6 @@
 
 packages:
   - package: dbt-labs/metrics
-    version: [">=0.3.0", "<0.4.0"]
+    version: [">=1.3.0-b1", "<1.4.0"]
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.1", "<0.9.0"]
+    version: [">=1.0.0", "<1.1.0"]


### PR DESCRIPTION
Updating packages to most recent version (metrics and dbt_utils), added a step in the readme file to run `dbt deps` before `dbt build` to install packages. And updated the surrogate_key function in stg_supplies to generate_surrogate_key due to the changes in dbt_utils 1.0. Confirmed once these changes were made, a `dbt build` works. 